### PR TITLE
Fix bug where from_name and from_email are not being properly set

### DIFF
--- a/src/MandrillChannel.php
+++ b/src/MandrillChannel.php
@@ -37,11 +37,11 @@ class MandrillChannel
             ->toArray();
 
         // Inject global "From" address if it's not in the message.
-        if (empty($message['from_email']) && ! empty(config('mail.from.address'))) {
+        if (empty($message['message']['from_email']) && ! empty(config('mail.from.address'))) {
             Arr::set($message, 'message.from_email', config('mail.from.address'));
         }
 
-        if (empty($message['from_name']) && ! empty(config('mail.from.name'))) {
+        if (empty($message['message']['from_name']) && ! empty(config('mail.from.name'))) {
             Arr::set($message, 'message.from_name', config('mail.from.name'));
         }
 

--- a/tests/MandrillChannelTest.php
+++ b/tests/MandrillChannelTest.php
@@ -93,4 +93,19 @@ class MandrillChannelTest extends TestCase
 
         $this->channel->send(new TestNotifiable(), new TestNotification());
     }
+
+    /** @test */
+    public function testSendWithFromNameAndEmail()
+    {
+        $this->mandrillMessages->shouldReceive('send')->with([
+            'from_email' => TestNotificationWithFromNameAndEmail::FROM_EMAIL,
+            'from_name' => TestNotificationWithFromNameAndEmail::FROM_NAME,
+            'to' => [[
+                'email' => 'a@b.com',
+                'name' => 'XYZ User'
+            ]],
+        ], null, null, null);
+
+        $this->channel->send(new TestNotifiable(), new TestNotificationWithFromNameAndEmail());
+    }
 }

--- a/tests/TestNotificationWithFromNameAndEmail.php
+++ b/tests/TestNotificationWithFromNameAndEmail.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace NotificationChannels\Mandrill\Tests;
+
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Mandrill\MandrillMessage;
+
+class TestNotificationWithFromNameAndEmail extends Notification
+{
+    const FROM_EMAIL = 'test@example.com';
+    const FROM_NAME = 'Custom Sender';
+
+    public function toMandrill($notifiable)
+    {
+        return (new MandrillMessage())
+            ->fromEmail(self::FROM_EMAIL)
+            ->fromName(self::FROM_NAME);
+    }
+}


### PR DESCRIPTION
In using this package, I noticed that all of our Mandrill notifications were coming from our default email, even though I was specifying custom sender information.

When creating a new message, the `MandrillChannel` was checking if `$message['from_email']` was specified. If not, it would use the default mail from address to set `$message['message']['from_email']`. It does the same for `from_name`. It seems as though it was missing the `['message']`.

The expected behavior is that the following code would set the from name and email on a Mandrill notification:

```php
$email = new Notification();
$email->fromEmail('test@example.com')
    ->fromName('Custom From Name');
```

This changes the code to check for `$message['message']['from_email']`. I've written an automated test and manually tested to validate that this works.

Mandrill API Docs: https://mandrillapp.com/api/docs/messages.html